### PR TITLE
10/20/2017 merge of latest pmgr code, incl. changesn and Zach's improvements

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -11,7 +11,7 @@ import re
 
 
 __all__ = ['docopt']
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 
 
 class DocoptLanguageError(Exception):

--- a/pmgrUtils.cfg
+++ b/pmgrUtils.cfg
@@ -8,7 +8,7 @@
 # listed although it *should* work with any hutch that is in the parameter
 # manager. Simply add the hutch name to the list below to add hutch
 # compatibility.
-supportedHutches = amo sxr sxd xpp xcs cxi mfx mec
+supportedHutches = amo sxr sxd xpp xcs cxi mfx mec det
 
 # This list is intended to allow for the script to handle newer objtypes as the
 # pmgr becomes gets used for more devices. The scripts *should* be able to

--- a/pmgrUtils.py
+++ b/pmgrUtils.py
@@ -557,8 +557,7 @@ if __name__ == "__main__":
             pmgr = utlp.getPmgr(objType, hutch, verbose)
             if not pmgr: continue
             # Look for obj (default is ims_motor type) with previous serial no
-            objDict = {'FLD_SN': oldSN}
-            objID = utlp.getObjWithSN(pmgr, objDict['FLD_SN'], verbose)
+            objID = utlp.getObjWithSN(pmgr, oldSN, verbose)
             if not objID: continue 
             print "Motor found: ObjID = {0}, hutch = {1}".format(objID, hutch.upper())
             # Create simple dict to change SN, then do it

--- a/pmgrUtils.sh
+++ b/pmgrUtils.sh
@@ -12,8 +12,9 @@ else
     sxd=false
 fi
 
-# Check if this is xpp or xcs
-if [[ "${2:0:3}" == "XPP" ]] || [[ "${2:0:3}" == "XCS" ]]; then
+# Check if this is a hard x-ray hutch
+if [[ "${2:0:3}" == "XPP" ]] || [[ "${2:0:3}" == "XCS" ]] || 
+[[ "${2:0:3}" == "MFX" ]] || [[ "${2:0:3}" == "CXI" ]] || [[ "${2:0:3}" == "MEC" ]]; then
     hxr=true
 else
     hxr=false

--- a/pmgrobj.py
+++ b/pmgrobj.py
@@ -830,7 +830,7 @@ class pmgrobj(object):
     def applyConfig(self, idx):
         vals = {}
         vals.update(self.objs[idx])
-        vals.update(self.cfgs[vals['config']])
+        vals.update(self.getConfig(vals['config']))
         base = vals['rec_base']
         if base == "":
             return

--- a/utils.py
+++ b/utils.py
@@ -100,7 +100,7 @@ def __get_callback(pv, e):
         pyca.flush_io()
 
 #
-# Do an assynchronous caget, but notify a threading.Event after it
+# Do an asynchronous caget, but notify a threading.Event after it
 # completes instead of just waiting.
 #
 def caget_async(pvname):

--- a/utilsPlus.py
+++ b/utilsPlus.py
@@ -77,7 +77,7 @@ def newObject(pmgr, objDict,typeStr=None, parent=None, owner=None):
 
     objectFields = listObjFields(pmgr)
 
-    # Pmgr doesnt handle missing fields well
+    # Pmgr doesn't handle missing fields well
     for field in objectFields:
         if field not in objDict:
             objDict[field] = "None" 
@@ -222,7 +222,10 @@ zeros to ensure proper pmgr functionality.".format(pmgr.objs[objID]["name"])
 
         if pmgrSN == SN: 
             return objID
-    
+
+    #If we get here, we know the SN wasn't found
+    if verbose:
+        print "Serial number {0} not found in {1} pmgr".format(SN,getHutch(pmgr).upper())
     return None    
 
 def getFieldDict(pmgr, PV, fields):
@@ -426,17 +429,17 @@ def getImportFieldDict(cfgPath):
 def updateConfig(PV, pmgr, objID, cfgID, objDict, cfgDict, allNames, verbose, 
                  rename=True):
     """ Routine to update the configuration of an obj """
-    # # PMGR cfg values for comparisons
+    # PMGR cfg values for comparisons
     objOld = pmgr.objs[objID]
     cfgOld = pmgr.cfgs[cfgID]
 
-    # # Print live values for troubleshooting
+    # Print live values for troubleshooting
     if verbose:
         print "\nLive cfg values for {0}".format(pv.get(PV+".DESC"))
         pprint(objDict)
         pprint(cfgDict)
 
-        print "\nPMGR cfg valu es for {0} before update".format(pv.get(PV+".DESC"))
+        print "\nPMGR cfg values for {0} before update".format(pv.get(PV+".DESC"))
         pprint(objOld)
         pprint(cfgOld)
         print
@@ -451,16 +454,15 @@ def updateConfig(PV, pmgr, objID, cfgID, objDict, cfgDict, allNames, verbose,
         cfgDict["name"] = incrementMatching(
             cfgDict["name"], allNames, maxLength=maxLenName)
 
-    # # Actually do the update
+    # Actually do the update
     print "Saving configuration..." 
     didWork = cfgChange(pmgr, cfgID, cfgDict)
 
     return didWork, objOld, cfgOld
 
-
 def motorPrelimChecks(PV, hutches, objType, verbose=False):
     """
-    Runs prelimenary checks on the paramter manager inputs, and returns a 
+    Runs preliminary checks on the parameter manager inputs, and returns a 
     valid hutch name, and serial number. Returns false
     for any of the variables if there are any issues when obtaining them.
     """
@@ -509,7 +511,6 @@ def motorPrelimChecks(PV, hutches, objType, verbose=False):
     # Wherever the function is called needs to have a check that ensures none of
     # the return values are None
 
-
 def dumbMotorCheck(PV):
     """
     Takes in a PV attempts caget on the PN nTries times and then checks the PN 
@@ -553,13 +554,14 @@ def getPmgr(objType, hutch, verbose):
     try:
         pmgr = pmgrobj(objType, hutch.lower())  # Launch pmgr instance
         pmgr.updateTables()                     # And update
-        if verbose: print "Pmgr instance initialized for hutch: {0}".format(hutch.upper())
+        if verbose: print "Pmgr instance initialized for hutch or area: {0}".format(hutch.upper())
     except:
         print "Failed to create pmgr instance for hutch: {0}".format(hutch.upper())
         pmgr = None
     return pmgr
 
-def printDiff(pmgr, objOld, cfgOld, objNew, cfgNew, verbose, **kwargs):
+def printDiff(pmgr, objOld, cfgOld, objNew, cfgNew, verbose, kind='diffs',
+              **kwargs):
     """ Prints the diffs between the old values and new values"""
     name1 = kwargs.get("name1", "New")
     name2 = kwargs.get("name2", "Old")
@@ -575,23 +577,36 @@ def printDiff(pmgr, objOld, cfgOld, objNew, cfgNew, verbose, **kwargs):
     diffs = {}
     ndiffs = 0
 
+    exclude_fields = ['FLD_TYPE']
     for field in cfgOld.keys():
+        if field in exclude_fields:
+            continue
         try:
-            if str(cfgNew[field]) != str(cfgOld[field]):
+            value1 = cfgNew[field]
+            value2 = cfgOld[field]
+            if None in [value1, value2]:
+                continue
+            if str(value1) != str(value2):
                 diffs[field] = "{0}: {1:<20}  {2}: {3:<20}".format(
                     name1, str(cfgNew[field]), name2, str(cfgOld[field]))
                 ndiffs += 1
         except: pass
 
     for field in objOld.keys():
+        if field in exclude_fields:
+            continue
         try:
-            if str(objNew[field]) != str(objOld[field]) and field not in fields.keys():
+            value1 = cfgNew[field]
+            value2 = cfgOld[field]
+            if None in [value1, value2]:
+                continue
+            if str(value1) != str(value2):
                 diffs[field] = "{0}: {1:<20}  {2}: {3:<20}".format(
                     name1, str(objNew[field]), name2, str(objOld[field]))
                 ndiffs += 1
         except: pass
 
-    print "\nNumber of diffs: {0}".format(ndiffs)
+    print "\nNumber of {0}: {1}".format(kind, ndiffs)
     if ndiffs > 0:
         for fld in diffs.keys():
             print "  {0:<15}: {1}".format(fld, diffs[fld])
@@ -605,7 +620,7 @@ def getAndSetConfig(PV, pmgr, objID, objDict, cfgDict, zenity=False):
     cfgDict["name"] = cfgName
     cfgDict["FLD_TYPE"] = "{0}_{1}".format(cfgName, PV[:4])
 
-    # # Create new cfg
+    # Create new cfg
     cfgID = newConfig(pmgr, cfgDict, cfgDict["name"])
 
     if not cfgID: 
@@ -613,7 +628,7 @@ def getAndSetConfig(PV, pmgr, objID, objDict, cfgDict, zenity=False):
         if zenity: system("zenity --error --text='Error: Failed to create new config'")
         return status
 
-    # # Set obj to use cfg
+    # Set obj to use cfg
     status = setObjCfg(pmgr, objID, cfgID)
     return status
 
@@ -641,7 +656,7 @@ def getMostRecentObj(hutches, SN, objType, verbose, zenity=False):
 
     # Make sure there is at least one obj with the corresponding SN
     if len(objs) == 0:
-        print "Failed to apply: Serial number {0} not found in pmgr".format(SN)
+        print "Failed: Serial number {0} not found in pmgr".format(SN)
         if zenity: system("zenity --error --text='Error: Motor not in pmgr'")
         return None, None
 
@@ -861,7 +876,21 @@ def objApply(pmgr, objID):
         return False
 
 def getHutch(pmgr):
-    return pmgr.hutch
+    try:
+        return pmgr.hutch
+    except AttributeError:
+        print "getHutch: Error, pmgr likely does not exist!"
+        exit()
+
+def getObjPV(pmgr, objID):
+    """
+    Returns last known PV for obj if it exists.
+    """
+    try:
+        return pmgr.objs[objID]["rec_base"]
+    except AttributeError:
+        print "getObjPV: Error with pmgr and/or objID, one or both may not exist!"
+        exit()
 
 def listCfgFields(pmgr):
     return listFieldsWith(pmgr, "obj", False)


### PR DESCRIPTION
r29266 | sstubbs | 2017-10-20 12:19:57 -0700 (Fri, 20 Oct 2017) | 1 line
Changed paths:
   M /package/trunk/pmgr/pmgrUtils.py

Fleshed out initial argument description
------------------------------------------------------------------------
r29263 | sstubbs | 2017-10-17 21:06:42 -0700 (Tue, 17 Oct 2017) | 1 line
Changed paths:
   M /package/trunk/pmgr/pmgrUtils.py

Typo fix in docstring
------------------------------------------------------------------------
r29262 | sstubbs | 2017-10-17 21:03:10 -0700 (Tue, 17 Oct 2017) | 1 line
Changed paths:
   M /package/trunk/pmgr/pmgrUtils.sh

This shouldn't be marked binary.
------------------------------------------------------------------------
r29261 | sstubbs | 2017-10-17 20:51:50 -0700 (Tue, 17 Oct 2017) | 6 lines
Changed paths:
   M /package/trunk/pmgr/docopt.py
   M /package/trunk/pmgr/pmgrUtils.cfg
   M /package/trunk/pmgr/pmgrUtils.py
   M /package/trunk/pmgr/pmgrUtils.sh
   M /package/trunk/pmgr/utils.py
   M /package/trunk/pmgr/utilsPlus.py

Added changesn feature to change serial no of pmgr objects, useful for replacing a broken motor.
Added getObjPV method to utilsPlus.py for when you need to get a PV, though not needed for changesn.
Added details to a few error messages.
Added 'det' to supportedHutches.
Cleaned up a few comments here and there.

------------------------------------------------------------------------
r29232 | zlentz | 2017-10-06 18:11:43 -0700 (Fri, 06 Oct 2017) | 6 lines
Changed paths:
   M /package/trunk/pmgr/pmgrUtils.py
   M /package/trunk/pmgr/pmgrobj.py
   M /package/trunk/pmgr/utilsPlus.py

Bugfix and QOL improvements for dumb motor helper scripts
- fix bug in pmgrobj where inherited parameters do not get applied to live objects
- allow us to pass optional 'name' to applyConfig as an alternative to syncing the Name and Config fields for dumb motors
- allow us to cancel a dumb apply if we can't figure out which config to use
- clean up the text readback of the diff prints